### PR TITLE
[forth] Add test-case for non-empty stack in builtin arithmetic funcs

### DIFF
--- a/forth/eval_test.go
+++ b/forth/eval_test.go
@@ -100,6 +100,11 @@ var testCases = []testCase{
 		expected:    []int{2},
 	},
 	{
+		description: "add non-empty stack",
+		input:       []string{"1 2 3 +"},
+		expected:    []int{1, 5},
+	},
+	{
 		description: "dup",
 		input:       []string{"1 dup"},
 		expected:    []int{1, 1},


### PR DESCRIPTION
Some context: in every builtin arithmetic function I accidentally returned head slices instead of tail ones.
Example:
```
stack = stack[initialLen-1:]
// instead of
stack = stack[:initialLen-1]
```
Although this is obviously incorrect, all the tests passed, because every arithmetic test case has exactly two operands (except for error cases), so here is very simple test case that would fail on such behaviour at least for my solution.