### PR TITLE
Add interface embedding in struct slide

### DIFF
--- a/lectures/02-interfaces/interfaces/embed.go
+++ b/lectures/02-interfaces/interfaces/embed.go
@@ -1,0 +1,21 @@
+package sort
+
+type Interface interface {
+	Len() int
+	Less(i, j int) bool
+	Swap(i, j int)
+}
+
+func Reverse(data Interface) Interface {
+	return &reverse{data}
+}
+
+type reverse struct {
+	// This embedded Interface permits Reverse to use the methods of
+	// another Interface implementation.
+	Interface
+}
+
+func (r reverse) Less(i, j int) bool {
+	return r.Interface.Less(j, i)
+}

--- a/lectures/02-interfaces/lecture.slide
+++ b/lectures/02-interfaces/lecture.slide
@@ -244,6 +244,12 @@ Methods
       Closer
   }
 
+* Interface embedding in struct
+
+.play interfaces/embed.go
+
+.link https://pkg.go.dev/github.com/go-chi/chi/v5/middleware#WrapResponseWriter Daily-life example
+
 * Interface satisfaction
 
   var w io.Writer

--- a/lectures/docker-compose.yaml
+++ b/lectures/docker-compose.yaml
@@ -1,0 +1,21 @@
+version: "3"
+services:
+  present:
+    build:
+      context: .
+    container_name: present
+    logging: &default_logging
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    entrypoint: |
+      /go/bin/present
+      -base /go/pkg/mod/golang.org/x/tools@v0.6.0/cmd/present
+      -http :8080
+      -orighost 127.0.0.1
+      -use_playground
+      -play=0


### PR DESCRIPTION
In our recent lecture, it was mentioned that embedding in Go is relatively uncommon, with the most notable use case being the embedding of interfaces within interfaces to create a logical sum of them. However, I believe we overlooked an important scenario: embedding an interface within a struct, particularly when overriding a subset of the methods defined by the original interface.

To address this gap, I have included a standard library example that demonstrates this approach. Additionally, I've provided a link to the chi library's WrappedResponseWriter as a practical example of interface embedding within a struct.

I also added docker-compose for convenient local present launch and debug
