### PR TITLE
Remove ctrl.Finish() from tests with mocks

### DIFF
--- a/distbuild/pkg/api/build_test.go
+++ b/distbuild/pkg/api/build_test.go
@@ -28,7 +28,6 @@ type env struct {
 
 func (e *env) stop() {
 	e.server.Close()
-	e.ctrl.Finish()
 }
 
 func newEnv(t *testing.T) (*env, func()) {

--- a/distbuild/pkg/api/heartbeat_test.go
+++ b/distbuild/pkg/api/heartbeat_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestHeartbeat(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	l := zaptest.NewLogger(t)
 	m := mock.NewMockHeartbeatService(ctrl)

--- a/lectures/04-testing/gomock/example_test.go
+++ b/lectures/04-testing/gomock/example_test.go
@@ -9,8 +9,6 @@ import (
 func TestFoo(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	defer ctrl.Finish() // Assert that Bar() is invoked.
-
 	m := NewMockFoo(ctrl)
 
 	// Asserts that the first and only call to Bar() is passed 99.

--- a/retryupdate/update_test.go
+++ b/retryupdate/update_test.go
@@ -97,7 +97,6 @@ func updateFn(oldValue *string) (string, error) {
 
 func TestSimpleUpdate(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	c := NewMockClient(ctrl)
 	gomock.InOrder(
@@ -115,7 +114,6 @@ func TestSimpleUpdate(t *testing.T) {
 
 func TestUpdateFnError(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	c := NewMockClient(ctrl)
 	gomock.InOrder(
@@ -128,7 +126,6 @@ func TestUpdateFnError(t *testing.T) {
 }
 func TestCreateKey(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	c := NewMockClient(ctrl)
 	gomock.InOrder(
@@ -146,7 +143,6 @@ func TestCreateKey(t *testing.T) {
 
 func TestKeyVanished(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	c := NewMockClient(ctrl)
 	gomock.InOrder(
@@ -168,7 +164,6 @@ func TestKeyVanished(t *testing.T) {
 
 func TestFailOnAuthErrorInGet(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	c := NewMockClient(ctrl)
 	gomock.InOrder(
@@ -182,7 +177,6 @@ func TestFailOnAuthErrorInGet(t *testing.T) {
 
 func TestFailOnAuthErrorInSet(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	c := NewMockClient(ctrl)
 	gomock.InOrder(
@@ -200,7 +194,6 @@ func TestFailOnAuthErrorInSet(t *testing.T) {
 
 func TestRetryGetError(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	c := NewMockClient(ctrl)
 	gomock.InOrder(
@@ -226,7 +219,6 @@ func TestRetryGetError(t *testing.T) {
 
 func TestRetrySetError(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	c := NewMockClient(ctrl)
 	gomock.InOrder(
@@ -248,7 +240,6 @@ func TestRetrySetError(t *testing.T) {
 
 func TestRetrySetConflict(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	c := NewMockClient(ctrl)
 	gomock.InOrder(
@@ -278,7 +269,6 @@ func TestRetrySetConflict(t *testing.T) {
 
 func TestRetrySetFalseConflict(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	conflictErr := &kvapi.ConflictError{ProvidedVersion: UUID0}
 


### PR DESCRIPTION
Since Go 1.14 it is no longer needed to call ```ctrl.Finish()``` to check if all expected methods were called: https://pkg.go.dev/github.com/golang/mock/gomock#Controller.Finish

> New in go1.14+, if you are passing a *testing.T into NewController function you no longer need to call ctrl.Finish() in your test methods.