### PR TITLE
Add new test to merge function

### DIFF
--- a/externalsort/sort_test.go
+++ b/externalsort/sort_test.go
@@ -34,6 +34,32 @@ func TestMerge(t *testing.T) {
 2
 `,
 		},
+		{
+			name: "with empty lines",
+			in: []string{`
+0`, `
+
+1
+1
+1`, `
+
+
+0
+2`},
+			out: `
+
+
+
+
+
+0
+0
+1
+1
+1
+2
+`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &bytes.Buffer{}


### PR DESCRIPTION
Если неаккуратно написать мердж, то тест на мердж это не отловит, а тест на сортировку сломается.
Для более ебыстрой локализации проблемы предлагаю добавить следующий тест для проверки работоспособности функции `merge`