### PR TITLE
[retryupdate] Add missing new line between test functions

### DIFF
--- a/retryupdate/update_test.go
+++ b/retryupdate/update_test.go
@@ -124,6 +124,7 @@ func TestUpdateFnError(t *testing.T) {
 
 	require.ErrorIs(t, retryupdate.UpdateValue(c, K0, updateFn), errUpdate)
 }
+
 func TestCreateKey(t *testing.T) {
 	ctrl := gomock.NewController(t)
 


### PR DESCRIPTION
For whatever reason test file did not have a new line between two functions.
I think that it should not cost any bonus points, but I just couldn't resist fixing it :)