### PR TITLE
[rwmutex] Deadlock test

### DIFF
--- a/rwmutex/rwmutex_test.go
+++ b/rwmutex/rwmutex_test.go
@@ -133,6 +133,7 @@ func TestRWMutex(t *testing.T) {
 }
 
 func TestWriteWriteReadDeadlock(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
 	runtime.GOMAXPROCS(2)
 	// Number of active readers + 10000 * number of active writers.
 	var activity int32

--- a/rwmutex/rwmutex_test.go
+++ b/rwmutex/rwmutex_test.go
@@ -131,3 +131,21 @@ func TestRWMutex(t *testing.T) {
 	HammerRWMutex(10, 10, n)
 	HammerRWMutex(10, 5, n)
 }
+
+func TestWriteWriteReadDeadlock(t *testing.T) {
+	runtime.GOMAXPROCS(2)
+	// Number of active readers + 10000 * number of active writers.
+	var activity int32
+	rwm := New()
+	cdone := make(chan bool, 3)
+
+	for i := 0; i < 2e6; i++ {
+		go writer(rwm, 1, &activity, cdone)
+		go writer(rwm, 1, &activity, cdone)
+		go reader(rwm, 1, &activity, cdone)
+		<-cdone
+		<-cdone
+		<-cdone
+	}
+
+}


### PR DESCRIPTION
Simple test that can cause some incorrect solutions to deadlock.

[The particular incorrect solution this test breaks.](https://gitlab.manytask.org/go/students-2024-spring/mayorov.m.a/-/blob/28e55989543ecc595ad7092e3d9bc14d85ef1384/rwmutex/rwmutex.go)

Locally the incorrect solution passes the test ~50% of the time with 1e5 iterations.
With 1e6 iterations it managed to pass the test once in ~100 attempts.
With 2e6 iterations it fails in <50ms ~85% of the time and ~15% of the time it takes it 1-2s to fail. The correct solution passes the test in ~3s.

Increasing the value in the "n := 1000" line in TestRWMutex doesn't make the incorrect solution fail.
