### PR TITLE
fix testCase for Clear method in the LruCache problem

### DIFF
--- a/lrucache/cache_test.go
+++ b/lrucache/cache_test.go
@@ -76,6 +76,37 @@ func TestCache_Clear(t *testing.T) {
 	require.Equal(t, []int{4, 3, 2, 1, 0}, values)
 }
 
+func TestCache_Clear_logic(t *testing.T) {
+	c := New(5)
+
+	for i := 0; i < 10; i++ {
+		c.Set(i, i)
+	}
+
+	c.Clear()
+
+	for i := 0; i < 10; i++ {
+		_, ok := c.Get(i)
+		require.False(t, ok)
+	}
+
+	c.Clear()
+
+	for i := 3; i >= 0; i-- {
+		c.Set(i, i)
+	}
+
+	var keys, values []int
+	c.Range(func(key, value int) bool {
+		keys = append(keys, key)
+		values = append(values, value)
+		return true
+	})
+
+	require.Equal(t, []int{3, 2, 1, 0}, keys)
+	require.Equal(t, []int{3, 2, 1, 0}, values)
+}
+
 func TestCache_Range(t *testing.T) {
 	c := New(5)
 


### PR DESCRIPTION
тесткейс не проверят функционал метода Clear (второй цикл вызовов Set переполняет LruCache)

в данной реализации с пустой реализацией Clear метода все чеки "зеленые"
https://gitlab.manytask.org/go/students-2024-spring/stepdan23/-/commit/76a733f03bde478a2647baff484122a10a028677
<img width="779" alt="image" src="https://github.com/slon/shad-go/assets/44161768/ac06b330-0cc8-494a-bfdd-1e36ae9637ef">
