### PR TITLE
Fix the cache cleanup test in the lrucache task

### DIFF
--- a/lrucache/cache_test.go
+++ b/lrucache/cache_test.go
@@ -55,13 +55,13 @@ func TestCache_Get(t *testing.T) {
 func TestCache_Clear(t *testing.T) {
 	c := New(5)
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 2; i++ {
 		c.Set(i, i)
 	}
 
 	c.Clear()
 
-	for i := 9; i >= 0; i-- {
+	for i := 4; i >= 1; i-- {
 		c.Set(i, i)
 	}
 
@@ -72,8 +72,8 @@ func TestCache_Clear(t *testing.T) {
 		return true
 	})
 
-	require.Equal(t, []int{4, 3, 2, 1, 0}, keys)
-	require.Equal(t, []int{4, 3, 2, 1, 0}, values)
+	require.Equal(t, []int{4, 3, 2, 1}, keys)
+	require.Equal(t, []int{4, 3, 2, 1}, values)
 }
 
 func TestCache_Clear_logic(t *testing.T) {


### PR DESCRIPTION
@pkositsyn 

**Исправлен неработающий тест очистки кэша в задаче lrucache.**

Тест TestCache_Clear фактически не проверял, реализован ли метод Clear и всегда завершался успешно. Результат один и тот же, что с очисткой кэша, что без нее.

