### PR TITLE
Correct a typo in the text of the externalsort task and add a comment to the retryupdate task

### DIFF
--- a/externalsort/README.md
+++ b/externalsort/README.md
@@ -24,7 +24,7 @@ func NewReader(r io.Reader) LineReader
 func NewWriter(w io.Writer) LineWriter
 ```
 
-`NewLineReader` оборачивает переданный `io.Reader` в `LineReader`.
+`NewReader` оборачивает переданный `io.Reader` в `LineReader`.
 
 Вызов `ReadLine` должен читать одну строку.
 Строка имеет произвольную длину.

--- a/retryupdate/update_test.go
+++ b/retryupdate/update_test.go
@@ -80,6 +80,8 @@ func SetRequest(k, v string, oldVersion uuid.UUID, saveUUID ...*uuid.UUID) gomoc
 	return m
 }
 
+// imitation of the client's sequence of actions: accepts the old key value
+// and returns a new value with which the key needs to be updated.
 func updateFn(oldValue *string) (string, error) {
 	switch {
 	case oldValue == nil:


### PR DESCRIPTION
@pkositsyn

**Исправление текста задачи externalsort и добавление комментария к задаче retryupdate.**

1. Задание retryupdate:
На мой взгляд, название функции updateFn выбрано неудачно. Это вспомогательная функция UpdateValue, но сам ключ в сервисе она не обновляет – этим занимается функция UpdateValue. Т.е. в названиях функций слово "update" используется в двух разных значениях, что усложняет понимание. Добавил комментарий, объясняющий роль функции updateFn.
2. Задание externalsort:
В тексте задания исправлена опечатка: упоминание названия несуществующей функции.
