### PR TITLE
add nested parallel test

### DIFF
--- a/tparallel/tparallel_test.go
+++ b/tparallel/tparallel_test.go
@@ -199,3 +199,27 @@ func TestTwoParallelSequences(t *testing.T) {
 		},
 	})
 }
+
+func TestNestedParallel(t *testing.T) {
+	check := ConcurrencyChecker{t: t}
+	defer check.Finish(3)
+	
+	Run([]func(*T){
+		func(t *T) {
+			t.Parallel()
+
+			t.Run(func(t *T) {
+				t.Parallel()
+
+				t.Run(func(t *T) {
+					t.Parallel()
+					check.Sequential(2)
+				})
+				
+				check.Sequential(1)
+			})
+
+			check.Sequential(0)
+		},
+	})
+}


### PR DESCRIPTION
Новый тест проверяет, что для параллельного теста его параллельные подтесты начинаются после заврешения самого теста. Я сам когда решал задачу запутался в логике работы, и тесты прошло решение, которое независимо от того, параллельный ли тест пыталось запустить параллельные подтесты до выхода из Run.