### PR TITLE
Add test WaitGroup noop on Wait() when counter reaches zero

### DIFF
--- a/waitgroup/waitgroup_test.go
+++ b/waitgroup/waitgroup_test.go
@@ -50,6 +50,19 @@ func recoverFromNegativeCounterPanic(t *testing.T) {
 	}
 }
 
+func TestNoop(t *testing.T) {
+	wg1 := New()
+	wg1.Wait()
+
+	wg1.Add(1)
+	go func() {
+		wg1.Done()
+	}()
+	wg1.Wait()
+	
+	wg1.Wait()
+}
+
 func TestWaitGroupDoneMisuse(t *testing.T) {
 	defer recoverFromNegativeCounterPanic(t)
 	wg := New()


### PR DESCRIPTION
У меня в приватном репозитории есть решение задачи https://gitlab.manytask.org/go/students-2024-spring/jellythefish/-/commit/6118101ca5af552baf3243fb1000048bacb55f24
Оно проходит все тесты, но не проходит тест из текущего PR.

Текущий тест проверяет условие из задачи: `Вызов Wait при числе равном нулю -- это no-op.`

На текущем тесте мы должны сразу вернуться из Wait в двух местах, поскольку в этих местах счетчик WaitGroup нулевой. Моя же реализация в приватном репозитории, проходящая все оригинальные тесты, зависает.