### PR TITLE
Update lectures/05-concurrency/lecture.slide

### DIFF
--- a/lectures/05-concurrency/lecture.slide
+++ b/lectures/05-concurrency/lecture.slide
@@ -133,8 +133,8 @@ Concurrency with Shared Memory
 
   func Deposit(amount int) {
       mu.Lock()
-      balance = balance + amount
-      mu.Unlock()
+      defer mu.Unlock()
+      balance += amount
   }
 
   func Balance() int {


### PR DESCRIPTION
simplify sum expression
use defer instead of unlock at the function end