### PR TITLE
fix(olympics): check bounds out of range for limit in top-athletes-in-sport test

### DIFF
--- a/olympics/testdata/tests/top-athletes-in-sport/29/in.json
+++ b/olympics/testdata/tests/top-athletes-in-sport/29/in.json
@@ -1,1 +1,1 @@
-{"sport": "Biathlon", "limit": 10}
+{"sport": "Biathlon", "limit": 321}


### PR DESCRIPTION
В тесте `top-countries-in-year` есть примеры, когда `limit` в реквесте превышает общее количество найденых результатов в json-файле. Из-за неправильной обработки можно получить `slice bounds out of range`. Это не проверяется в хендлере для `top-athletes-in-sport`.  Этот PR направлен на добавление такого примера.

Вот однострочник :trollface:, который показывает, что такого примера в `top-athletes-in-sport` нет:
```bash
(cd olympics/testdata/tests/top-athletes-in-sport; for i in $(ls); do echo "limit_in=$(cat "$i/in.json" | jq ".limit") response_count=$(cat "$i/out.json" | jq "length")"; done)
```