### PR TITLE
Use docker compose and properly wait for DB

### DIFF
--- a/dao/README.md
+++ b/dao/README.md
@@ -38,11 +38,11 @@ go test -v ./dockertest/...
 
 Запускать тесты можно будет так:
 ```
-(cd dao && docker-compose up -d && sleep 1 && env PGCONN="host=127.0.0.1 port=5432 database=shad-go user=gopher password=pass" go test -v ./... -count=1 || true && docker-compose down)
+(cd dao && docker compose up -d --wait && env PGCONN="host=127.0.0.1 port=5432 database=shad-go user=gopher password=pass" go test -v ./... -count=1 || true && docker compose down)
 ```
 Эта команда стартует docker с postgresql, запускает тесты, передав им DSN через переменную окружения, удаляет контейнеры в конце.
 
 Как подчистить контейнеры, если что-то пошло не так:
 ```
-(cd dao && docker-compose down)
+(cd dao && docker compose down)
 ```

--- a/dao/docker-compose.yaml
+++ b/dao/docker-compose.yaml
@@ -8,3 +8,8 @@ services:
       POSTGRES_PASSWORD: pass
     ports:
       - 5432:5432
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER}" ]
+      interval: 1s
+      timeout: 3s
+      retries: 5

--- a/ledger/docker-compose.yaml
+++ b/ledger/docker-compose.yaml
@@ -8,3 +8,8 @@ services:
       POSTGRES_PASSWORD: pass
     ports:
       - 5432:5432
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER}" ]
+      interval: 1s
+      timeout: 3s
+      retries: 5

--- a/shopfront/README.md
+++ b/shopfront/README.md
@@ -25,5 +25,5 @@ sudo apt install redis-server
 Комментарии по запуску бд в docker смотрите в задаче [dao](../dao/).
 
 ```
-(cd shopfront && docker-compose up -d && sleep 1 && env REDIS="localhost:6379" go test -v ./... -count=1 || true && docker-compose down)
+(cd shopfront && docker compose up -d --wait && env REDIS="localhost:6379" go test -v ./... -count=1 || true && docker compose down)
 ```

--- a/shopfront/docker-compose.yaml
+++ b/shopfront/docker-compose.yaml
@@ -6,3 +6,8 @@ services:
     hostname: redis
     ports:
       - "6379:6379"
+    healthcheck:
+      test:  ["CMD", "redis-cli", "--raw", "incr", "ping" ]
+      interval: 1s
+      timeout: 3s
+      retries: 5


### PR DESCRIPTION
1. `docker-compose` (который через дефис и поставлялся отдельным бинарем) с июля 2023 объявлен устаревшим. Вместо него нужно использовать `docker compose`, который поставляется с основным бинарем докера
https://docs.docker.com/compose/migrate/
2. Удалил из задач костыльный `sleep 1`, добавил полноценный healthcheck и флажок `--wait`, чтобы cli дожидался успешного healthcheck перед стартом