### PR TITLE
[excelwriter] Fix typo. Update writer_test.go

### DIFF
--- a/excelwriter/writer_test.go
+++ b/excelwriter/writer_test.go
@@ -30,7 +30,7 @@ type Basic struct {
 	Bool   bool    `xlsx:"bool"`
 	String string  `xlsx:"string"`
 
-	MyInt int `xlsx:"my_int"`
+	MyInt MyInt `xlsx:"my_int"`
 }
 
 type Inner struct {


### PR DESCRIPTION
В тестах вводится alias MyInt для инта. Но это заряженное ружье нигде не стреляет. Предлагаю заиспользовать его в структуре