### PR TITLE
cipher - rename `NewReader/Writer` into `makeReader/Writer` (or return by pointer)

### DIFF
--- a/otp/cipher.go
+++ b/otp/cipher.go
@@ -6,10 +6,10 @@ import (
 	"io"
 )
 
-func NewReader(r io.Reader, prng io.Reader) io.Reader {
+func makeReader(r io.Reader, prng io.Reader) io.Reader {
 	panic("implement me")
 }
 
-func NewWriter(w io.Writer, prng io.Reader) io.Writer {
+func makeWriter(w io.Writer, prng io.Reader) io.Writer {
 	panic("implement me")
 }

--- a/otp/cipher_test.go
+++ b/otp/cipher_test.go
@@ -89,7 +89,7 @@ func TestReader(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			r := NewReader(testCase.r, testCase.prng)
+			r := makeReader(testCase.r, testCase.prng)
 
 			buf, err := io.ReadAll(r)
 			require.ErrorIs(t, err, testCase.err)
@@ -106,7 +106,7 @@ func TestWriterSimple(t *testing.T) {
 	out := &bytes.Buffer{}
 	prng := bytes.NewBuffer(randomBytes)
 
-	w := NewWriter(out, prng)
+	w := makeWriter(out, prng)
 	n, err := w.Write(plaintext)
 
 	require.Equalf(t, plaintextBackup, plaintext, "Write must not modify the slice data, even temporarily.")
@@ -140,7 +140,7 @@ func TestWriterError(t *testing.T) {
 	out := &errWriter{n: 512}
 	prng := bytes.NewBuffer(randomBytes)
 
-	w := NewWriter(out, prng)
+	w := makeWriter(out, prng)
 	n, err := w.Write(plaintext)
 
 	require.Equalf(t, plaintextBackup, plaintext, "Write must not modify the slice data, even temporarily.")
@@ -156,5 +156,5 @@ func (panicReader) Read([]byte) (int, error) {
 }
 
 func TestNewReaderNotReading(t *testing.T) {
-	_ = NewReader(panicReader{}, panicReader{})
+	_ = makeReader(panicReader{}, panicReader{})
 }


### PR DESCRIPTION
Сейчас функции называются `New*` и возвращают по значению. Однако обычно функции, называющиеся `NewSomething` возвращают по указателю.

Предлагаю либо переименовать на `make*`, либо возвращать по указателю. Кажется, так будет более семантично / консистентно со страндартными функциями `new` и `make`.

Единственно, я не уверена, что вообще приняты функции `makeSomething`, сходу все что гуглится называется именно `NewSomething` и возвращает указатель.

Не самый авторитетный источник, но вот anecdotal evidence:
https://stackoverflow.com/a/18125682/3478131