### PR TITLE
Gopls quickfixes

### DIFF
--- a/allocs/allocs_test.go
+++ b/allocs/allocs_test.go
@@ -34,7 +34,7 @@ func Benchmark(b *testing.B) {
 	b.Run("count", func(b *testing.B) {
 		r := strings.NewReader(data)
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			c := NewEnhancedCounter()
 			_ = c.Count(r)
 		}
@@ -43,7 +43,7 @@ func Benchmark(b *testing.B) {
 	b.Run("main", func(b *testing.B) {
 		r := strings.NewReader(data)
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			c := NewEnhancedCounter()
 			_ = c.Count(r)
 			_ = c.String()

--- a/allocs/baseline.go
+++ b/allocs/baseline.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"slices"
 )
 
 type Counter interface {
@@ -28,8 +29,8 @@ func (c BaselineCounter) Count(r io.Reader) error {
 		return err
 	}
 	dataStr := string(data)
-	for _, line := range strings.Split(dataStr, "\n") {
-		for _, word := range strings.Split(line, " ") {
+	for line := range strings.SplitSeq(dataStr, "\n") {
+		for word := range strings.SplitSeq(line, " ") {
 			c.counts[word]++
 		}
 	}
@@ -41,9 +42,7 @@ func (c BaselineCounter) String() string {
 	for word := range c.counts {
 		keys = append(keys, word)
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i] < keys[j]
-	})
+	slices.Sort(keys)
 
 	result := ""
 	for _, key := range keys {

--- a/batcher/slow/value.go
+++ b/batcher/slow/value.go
@@ -10,11 +10,11 @@ import (
 
 type Value struct {
 	mu          sync.Mutex
-	value       interface{}
+	value       any
 	readRunning int32
 }
 
-func (s *Value) Load() interface{} {
+func (s *Value) Load() any {
 	if atomic.SwapInt32(&s.readRunning, 1) == 1 {
 		panic("another load is running")
 	}
@@ -28,7 +28,7 @@ func (s *Value) Load() interface{} {
 	return value
 }
 
-func (s *Value) Store(v interface{}) {
+func (s *Value) Store(v any) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/cond/cond_test.go
+++ b/cond/cond_test.go
@@ -13,7 +13,7 @@ func TestCondSignal(t *testing.T) {
 	n := 2
 	running := make(chan bool, n)
 	awake := make(chan bool, n)
-	for i := 0; i < n; i++ {
+	for range n {
 		go func() {
 			m.Lock()
 			running <- true
@@ -22,7 +22,7 @@ func TestCondSignal(t *testing.T) {
 			m.Unlock()
 		}()
 	}
-	for i := 0; i < n; i++ {
+	for range n {
 		<-running // Wait for everyone to run.
 	}
 	for n > 0 {
@@ -51,7 +51,7 @@ func TestCondSignalOveruse(t *testing.T) {
 	running := make(chan bool, 1)
 	awake := make(chan bool, 1)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		c.Signal() // Checks if empty signals are not deadlocking
 	}
 
@@ -83,7 +83,7 @@ func TestCondSignalGenerations(t *testing.T) {
 	n := 100
 	running := make(chan bool, n)
 	awake := make(chan int, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		go func(i int) {
 			m.Lock()
 			running <- true
@@ -112,7 +112,7 @@ func TestCondBroadcast(t *testing.T) {
 	running := make(chan int, n)
 	awake := make(chan int, n)
 	exit := false
-	for i := 0; i < n; i++ {
+	for i := range n {
 		go func(g int) {
 			m.Lock()
 			for !exit {
@@ -123,8 +123,8 @@ func TestCondBroadcast(t *testing.T) {
 			m.Unlock()
 		}(i)
 	}
-	for i := 0; i < n; i++ {
-		for i := 0; i < n; i++ {
+	for i := range n {
+		for range n {
 			<-running // Will deadlock unless n are running.
 		}
 		if i == n-1 {
@@ -141,7 +141,7 @@ func TestCondBroadcast(t *testing.T) {
 		c.Broadcast()
 		m.Unlock()
 		seen := make([]bool, n)
-		for i := 0; i < n; i++ {
+		for range n {
 			g := <-awake
 			if seen[g] {
 				t.Fatal("goroutine woke up twice")
@@ -159,7 +159,7 @@ func TestCondBroadcast(t *testing.T) {
 
 // nolint
 func TestCondSignalStealing(t *testing.T) {
-	for iters := 0; iters < 20000; iters++ {
+	for range 20000 {
 		var m sync.Mutex
 		cond := New(&m)
 

--- a/consistenthash/hash_test.go
+++ b/consistenthash/hash_test.go
@@ -34,12 +34,12 @@ func TestHash_TwoNodes(t *testing.T) {
 
 	n := h.GetNode("key0")
 	require.True(t, n == &n1 || n == &n2)
-	for i := 0; i < 32; i++ {
+	for range 32 {
 		require.Equal(t, n, h.GetNode("key0"))
 	}
 
 	differs := false
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		other := h.GetNode(fmt.Sprintf("key%d", i))
 		if other != n {
 			differs = true
@@ -52,14 +52,14 @@ func TestHash_EvenDistribution(t *testing.T) {
 	h := New[node]()
 
 	const K = 32
-	for i := 0; i < K; i++ {
+	for i := range K {
 		n := node(fmt.Sprint(i))
 		h.AddNode(&n)
 	}
 
 	counts := map[*node]float64{}
 	const N = 1 << 16
-	for i := 0; i < N; i++ {
+	for i := range N {
 		counts[h.GetNode(fmt.Sprintf("key%d", i))] += 1
 	}
 
@@ -88,7 +88,7 @@ func TestHash_ConsistentDistribution(t *testing.T) {
 	h := New[node]()
 
 	const K = 32
-	for i := 0; i < K; i++ {
+	for i := range K {
 		n := node(fmt.Sprint(i))
 		h.AddNode(&n)
 	}
@@ -96,7 +96,7 @@ func TestHash_ConsistentDistribution(t *testing.T) {
 	nodes := map[string]*node{}
 
 	const N = 1 << 16
-	for i := 0; i < N; i++ {
+	for i := range N {
 		key := fmt.Sprintf("key%d", i)
 		nodes[key] = h.GetNode(key)
 	}
@@ -127,13 +127,13 @@ func BenchmarkHashSpeed(b *testing.B) {
 	for _, K := range []int{32, 1024, 4096} {
 		h := New[node]()
 
-		for i := 0; i < K; i++ {
+		for i := range K {
 			n := node(fmt.Sprint(i))
 			h.AddNode(&n)
 		}
 
 		b.Run(fmt.Sprintf("K=%d", K), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for i := 0; b.Loop(); i++ {
 				_ = h.GetNode(fmt.Sprintf("key%d", i))
 			}
 		})

--- a/coverme/utils/httputils.go
+++ b/coverme/utils/httputils.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-func RespondJSON(w http.ResponseWriter, status int, data interface{}) error {
+func RespondJSON(w http.ResponseWriter, status int, data any) error {
 	response, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/digitalclock/main_test.go
+++ b/digitalclock/main_test.go
@@ -91,8 +91,8 @@ func calcImgDiff(i1, i2 image.Image) float64 {
 	w, h := i1.Bounds().Dx(), i1.Bounds().Dy()
 
 	var sum int64
-	for x := 0; x < w; x++ {
-		for y := 0; y < h; y++ {
+	for x := range w {
+		for y := range h {
 			r1, g1, b1, _ := i1.At(x, y).RGBA()
 			r2, g2, b2, _ := i2.At(x, y).RGBA()
 			sum += abs(r1, r2)

--- a/distbuild/disttest/fixture.go
+++ b/distbuild/disttest/fixture.go
@@ -126,7 +126,7 @@ func newEnv(t *testing.T, config *Config) (e *env) {
 	router := http.NewServeMux()
 	router.Handle("/coordinator/", http.StripPrefix("/coordinator", env.Coordinator))
 
-	for i := 0; i < config.WorkerCount; i++ {
+	for i := range config.WorkerCount {
 		workerName := fmt.Sprintf("worker%d", i)
 		workerDir := filepath.Join(env.RootDir, workerName)
 

--- a/distbuild/disttest/three_workers_test.go
+++ b/distbuild/disttest/three_workers_test.go
@@ -28,7 +28,7 @@ func TestArtifactTransferBetweenWorkers(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(3)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		depJobID := build.ID{'b', byte(i)}
 		depJob := build.Job{
 			ID:   depJobID,

--- a/distbuild/pkg/api/build_test.go
+++ b/distbuild/pkg/api/build_test.go
@@ -137,8 +137,7 @@ func TestBuildResultsStreaming(t *testing.T) {
 	env, stop := newEnv(t)
 	defer stop()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	buildID := build.ID{02}
 	req := &api.BuildRequest{}

--- a/distbuild/pkg/artifact/cache.go
+++ b/distbuild/pkg/artifact/cache.go
@@ -42,7 +42,7 @@ func NewCache(root string) (*Cache, error) {
 		return nil, err
 	}
 
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		d := hex.EncodeToString([]byte{uint8(i)})
 		if err := os.MkdirAll(filepath.Join(cacheDir, d), 0777); err != nil {
 			return nil, err

--- a/distbuild/pkg/filecache/client_test.go
+++ b/distbuild/pkg/filecache/client_test.go
@@ -83,12 +83,12 @@ func TestFileUpload(t *testing.T) {
 			G = 10
 		)
 
-		for i := 0; i < N; i++ {
+		for i := range N {
 			var wg sync.WaitGroup
 			wg.Add(G)
 
 			id := build.ID{0x03, byte(i)}
-			for j := 0; j < G; j++ {
+			for range G {
 				go func() {
 					defer wg.Done()
 

--- a/dupcall/dupcall.go
+++ b/dupcall/dupcall.go
@@ -9,5 +9,5 @@ type Call struct {
 
 func (o *Call) Do(
 	ctx context.Context,
-	cb func(context.Context) (interface{}, error),
-) (result interface{}, err error)
+	cb func(context.Context) (any, error),
+) (result any, err error)

--- a/fileleak/fileleak.go
+++ b/fileleak/fileleak.go
@@ -3,7 +3,7 @@
 package fileleak
 
 type testingT interface {
-	Errorf(msg string, args ...interface{})
+	Errorf(msg string, args ...any)
 	Cleanup(func())
 }
 

--- a/fileleak/fileleak_test.go
+++ b/fileleak/fileleak_test.go
@@ -20,7 +20,7 @@ type fakeT struct {
 	cleanup []func()
 }
 
-func (f *fakeT) Errorf(msg string, args ...interface{}) {
+func (f *fakeT) Errorf(msg string, args ...any) {
 	f.failed = true
 	fmt.Fprintf(&f.buffer, msg, args...)
 }

--- a/gzep/encode_test.go
+++ b/gzep/encode_test.go
@@ -20,9 +20,9 @@ func BenchmarkEncode(b *testing.B) {
 		"value without an allocation.",
 	)
 
-	b.ResetTimer()
+	
 	b.ReportAllocs()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		require.NoError(b, gzep.Encode(data, io.Discard))
 	}
 }
@@ -55,7 +55,7 @@ func TestEncode_Stress(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	n := 100
-	for i := 0; i < n; i++ {
+	for range n {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/hotelbusiness/hotels_test.go
+++ b/hotelbusiness/hotels_test.go
@@ -71,7 +71,7 @@ func TestComputeLoad_basic(t *testing.T) {
 func TestComputeLoad_stress1(t *testing.T) {
 	n := 1000000
 	g := make([]Guest, 0, 1000000)
-	for i := 0; i < n; i++ {
+	for range n {
 		g = append(g, Guest{1, 2})
 	}
 	l := ComputeLoad(g)
@@ -81,7 +81,7 @@ func TestComputeLoad_stress1(t *testing.T) {
 func TestComputeLoad_stress2(t *testing.T) {
 	n := 1000000
 	g := make([]Guest, 0, 1000000)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		g = append(g, Guest{i, i + 1})
 	}
 	l := ComputeLoad(g)

--- a/illegal/field.go
+++ b/illegal/field.go
@@ -2,5 +2,5 @@
 
 package illegal
 
-func SetPrivateField(obj interface{}, name string, value interface{}) {
+func SetPrivateField(obj any, name string, value any) {
 }

--- a/iprange/iprange_test.go
+++ b/iprange/iprange_test.go
@@ -33,7 +33,7 @@ func TestCIDRAddress(t *testing.T) {
 
 		out := ipRange.Expand()
 		assert.Equal(t, int(0xffffffff-0xffffff00), len(out)-1)
-		for i := 0; i < 256; i++ {
+		for i := range 256 {
 			assert.Equal(t, net.IP([]byte{192, 168, 2, byte(i)}), out[i])
 		}
 	}
@@ -47,7 +47,7 @@ func TestCIDRAddress(t *testing.T) {
 
 		out := ipRange.Expand()
 		assert.Equal(t, int(0xffffffff-0xffff0000), len(out)-1)
-		for i := 0; i < 65536; i++ {
+		for i := range 65536 {
 			assert.Equal(t, net.IP([]byte{10, 1, byte(i / 256), byte(i % 256)}), out[i])
 		}
 	}

--- a/jsonlist/jsonlist.go
+++ b/jsonlist/jsonlist.go
@@ -4,10 +4,10 @@ package jsonlist
 
 import "io"
 
-func Marshal(w io.Writer, slice interface{}) error {
+func Marshal(w io.Writer, slice any) error {
 	panic("implement me")
 }
 
-func Unmarshal(r io.Reader, slice interface{}) error {
+func Unmarshal(r io.Reader, slice any) error {
 	panic("implement me")
 }

--- a/jsonlist/jsonlist_test.go
+++ b/jsonlist/jsonlist_test.go
@@ -12,13 +12,13 @@ import (
 type S struct {
 	A string
 	B int
-	C interface{}
+	C any
 }
 
 func TestJsonList(t *testing.T) {
 	for _, test := range []struct {
 		js    string
-		value interface{}
+		value any
 	}{
 		{
 			js:    `1 2 3`,
@@ -34,7 +34,7 @@ func TestJsonList(t *testing.T) {
 		},
 		{
 			js:    `"A" 2`,
-			value: []interface{}{"A", 2.0},
+			value: []any{"A", 2.0},
 		},
 	} {
 		t.Run(test.js, func(t *testing.T) {

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 )
 
-func MakeHandler(service interface{}) http.Handler {
+func MakeHandler(service any) http.Handler {
 	panic("implement me")
 }
 
-func Call(ctx context.Context, endpoint string, method string, req, rsp interface{}) error {
+func Call(ctx context.Context, endpoint string, method string, req, rsp any) error {
 	panic("implement me")
 }

--- a/keylock/keylock_test.go
+++ b/keylock/keylock_test.go
@@ -89,7 +89,7 @@ func TestKeyLock_DeadlockFree(t *testing.T) {
 	checkLock := func(keys []string) {
 		defer wg.Done()
 
-		for i := 0; i < N; i++ {
+		for range N {
 			cancelled, unlock := l.LockKeys(keys, nil)
 			if cancelled {
 				t.Error("spurious lock failure")
@@ -132,11 +132,11 @@ func TestKeyLock_SingleKeyStress(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(G)
 
-	for i := 0; i < G; i++ {
+	for range G {
 		go func() {
 			defer wg.Done()
 
-			for j := 0; j < N; j++ {
+			for range N {
 				cancelled, unlock := l.LockKeys([]string{"a"}, timeout(time.Millisecond))
 				if !cancelled {
 					unlock()
@@ -166,13 +166,13 @@ func TestKeyLock_MutualExclusionStress(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(G)
 
-	for i := 0; i < G; i++ {
+	for range G {
 		go func() {
 			defer wg.Done()
 
-			for j := 0; j < N; j++ {
+			for range N {
 				keys := []string{}
-				for k := 0; k < K; k++ {
+				for range K {
 					keys = append(keys, fmt.Sprint(rand.Intn(N)))
 				}
 

--- a/keylock/speed_test.go
+++ b/keylock/speed_test.go
@@ -56,16 +56,16 @@ func BenchmarkKeyLock_NoBusyWait(b *testing.B) {
 
 	cancel := make(chan struct{})
 	defer close(cancel)
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		go func() {
 			l.LockKeys(lockedKey, cancel)
 		}()
 	}
 
-	b.ResetTimer()
+	
 
 	openKey := []string{"a"}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		canceled, unlock := l.LockKeys(openKey, nil)
 		if canceled {
 			b.Fatal("spurious lock fail")

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -104,7 +104,7 @@ func TestLedger(t *testing.T) {
 		const initialBalance = 5
 
 		var accounts []ledger.ID
-		for i := 0; i < nAccounts; i++ {
+		for i := range nAccounts {
 			id := ledger.ID(fmt.Sprint(i))
 			accounts = append(accounts, id)
 
@@ -138,7 +138,7 @@ func TestLedger(t *testing.T) {
 			}()
 		}
 
-		for i := 0; i < nAccounts; i++ {
+		for i := range nAccounts {
 			i := i
 
 			account := accounts[i]
@@ -172,7 +172,7 @@ func TestLedger(t *testing.T) {
 		wg.Wait()
 
 		var total ledger.Money
-		for i := 0; i < nAccounts; i++ {
+		for i := range nAccounts {
 			amount, err := l0.GetBalance(ctx, accounts[i])
 			require.NoError(t, err)
 

--- a/lrucache/cache_test.go
+++ b/lrucache/cache_test.go
@@ -32,7 +32,7 @@ func TestCache_update(t *testing.T) {
 func TestCache_Get(t *testing.T) {
 	c := New(5)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		c.Set(i, i)
 	}
 
@@ -55,7 +55,7 @@ func TestCache_Get(t *testing.T) {
 func TestCache_Clear(t *testing.T) {
 	c := New(5)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		c.Set(i, i)
 	}
 
@@ -79,13 +79,13 @@ func TestCache_Clear(t *testing.T) {
 func TestCache_Clear_logic(t *testing.T) {
 	c := New(5)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		c.Set(i, i)
 	}
 
 	c.Clear()
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		_, ok := c.Get(i)
 		require.False(t, ok)
 	}
@@ -110,7 +110,7 @@ func TestCache_Clear_logic(t *testing.T) {
 func TestCache_Range(t *testing.T) {
 	c := New(5)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		c.Set(i, i)
 	}
 
@@ -157,7 +157,7 @@ func TestCache_eviction(t *testing.T) {
 			c := New(tc.cap)
 
 			keyToValue := make(map[int]int)
-			for i := 0; i < tc.numInserts; i++ {
+			for i := range tc.numInserts {
 				key := int(r.Int31n(tc.maxKey))
 				c.Set(key, i)
 				keyToValue[key] = i
@@ -171,10 +171,7 @@ func TestCache_eviction(t *testing.T) {
 				return true
 			})
 
-			expectedLen := tc.cap
-			if len(keyToValue) < tc.cap {
-				expectedLen = len(keyToValue)
-			}
+			expectedLen := min(len(keyToValue), tc.cap)
 			require.Len(t, values, expectedLen)
 			require.True(t, sort.IntsAreSorted(values), "values: %+v", values)
 
@@ -214,7 +211,7 @@ func BenchmarkCache_Set(b *testing.B) {
 			c := New(tc.cap)
 			b.ResetTimer()
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for i := 0; b.Loop(); i++ {
 				c.Set(i%tc.cap, i)
 			}
 		})

--- a/middleware/httpgauge/httpgauge_test.go
+++ b/middleware/httpgauge/httpgauge_test.go
@@ -36,12 +36,12 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 
-			for j := 0; j < 1000; j++ {
+			for j := range 1000 {
 				m.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", fmt.Sprintf("/user/%d", j), nil))
 			}
 		}()

--- a/olympics/main_test.go
+++ b/olympics/main_test.go
@@ -90,7 +90,7 @@ func TestServer_valid(t *testing.T) {
 					out, err := os.ReadFile(path.Join(testDir, f.Name(), "out.json"))
 					require.NoError(t, err)
 
-					var values map[string]interface{}
+					var values map[string]any
 					require.NoError(t, json.Unmarshal(in, &values))
 
 					resp, err := c.R().
@@ -101,13 +101,13 @@ func TestServer_valid(t *testing.T) {
 					require.Equal(t, http.StatusOK, resp.StatusCode())
 					require.Contains(t, resp.Header().Get("Content-Type"), "application/json")
 
-					var got interface{}
+					var got any
 					err = json.Unmarshal(resp.Body(), &got)
 					if err != nil {
 						t.Fatalf("Could not parse response body: %v", err)
 					}
 
-					var want interface{}
+					var want any
 					_ = json.Unmarshal(out, &want)
 
 					if diff := cmp.Diff(want, got); diff != "" {
@@ -185,7 +185,7 @@ func TestServer_invalid(t *testing.T) {
 	}
 }
 
-func toURLValues(in map[string]interface{}) map[string]string {
+func toURLValues(in map[string]any) map[string]string {
 	out := make(map[string]string)
 	for k, v := range in {
 		out[k] = fmt.Sprintf("%v", v)

--- a/once/once_test.go
+++ b/once/once_test.go
@@ -25,10 +25,10 @@ func TestOnce(t *testing.T) {
 	once := New()
 	c := make(chan bool)
 	const N = 10
-	for i := 0; i < N; i++ {
+	for range N {
 		go run(t, once, o, c)
 	}
-	for i := 0; i < N; i++ {
+	for range N {
 		<-c
 	}
 	if *o != 1 {
@@ -57,7 +57,7 @@ func TestOncePanic(t *testing.T) {
 
 func TestOnceManyTimes(t *testing.T) {
 	const N = 1000
-	for i := 0; i < N; i++ {
+	for range N {
 		TestOnce(t)
 	}
 }
@@ -68,7 +68,7 @@ func TestOnceNoBusyWait(t *testing.T) {
 	done := make(chan struct{})
 	defer close(done)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		go once.Do(func() {
 			<-done
 		})

--- a/pubsub/my_pubsub.go
+++ b/pubsub/my_pubsub.go
@@ -24,7 +24,7 @@ func (p *MyPubSub) Subscribe(subj string, cb MsgHandler) (Subscription, error) {
 	panic("implement me")
 }
 
-func (p *MyPubSub) Publish(subj string, msg interface{}) error {
+func (p *MyPubSub) Publish(subj string, msg any) error {
 	panic("implement me")
 }
 

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -5,7 +5,7 @@ package pubsub
 import "context"
 
 // MsgHandler is a callback function that processes messages delivered to subscribers.
-type MsgHandler func(msg interface{})
+type MsgHandler func(msg any)
 
 type Subscription interface {
 	// Unsubscribe will remove interest in the given subject.
@@ -17,7 +17,7 @@ type PubSub interface {
 	Subscribe(subj string, cb MsgHandler) (Subscription, error)
 
 	// Publish publishes the msg argument to the given subject.
-	Publish(subj string, msg interface{}) error
+	Publish(subj string, msg any) error
 
 	// Close will shutdown pub-sub system.
 	// May be blocked by data delivery until the context is canceled.

--- a/pubsub/pubsub_example_test.go
+++ b/pubsub/pubsub_example_test.go
@@ -13,7 +13,7 @@ func ExamplePubSub() {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
-	_, err := p.Subscribe("single", func(msg interface{}) {
+	_, err := p.Subscribe("single", func(msg any) {
 		fmt.Println("new message:", msg)
 		// Output: new message: blah-blah
 		wg.Done()

--- a/redisfixture/fixture.go
+++ b/redisfixture/fixture.go
@@ -13,9 +13,9 @@ import (
 )
 
 type testingTB interface {
-	Logf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
+	Logf(format string, args ...any)
+	Fatalf(format string, args ...any)
+	Errorf(format string, args ...any)
 	FailNow()
 	Cleanup(func())
 }

--- a/retryupdate/update_test.go
+++ b/retryupdate/update_test.go
@@ -44,7 +44,7 @@ type setMatcher struct {
 	save *uuid.UUID
 }
 
-func (m setMatcher) Matches(x interface{}) bool {
+func (m setMatcher) Matches(x any) bool {
 	if arg, ok := x.(*kvapi.SetRequest); ok {
 		if m.save != nil {
 			*m.save = arg.NewVersion

--- a/reversemap/reversemap.go
+++ b/reversemap/reversemap.go
@@ -2,6 +2,6 @@
 
 package reversemap
 
-func ReverseMap(forward interface{}) interface{} {
+func ReverseMap(forward any) any {
 	panic("implement me")
 }

--- a/reversemap/reversemap_test.go
+++ b/reversemap/reversemap_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestReverseMap(t *testing.T) {
 	data := []struct {
-		forward  interface{}
-		backward interface{}
+		forward  any
+		backward any
 	}{
 		{
 			forward: map[string]string{

--- a/rsem/rsem_test.go
+++ b/rsem/rsem_test.go
@@ -80,7 +80,7 @@ func TestSemaphore_IndependentKeys(t *testing.T) {
 
 	ctx := context.Background()
 
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		sem := NewSemaphore(rdb)
 
 		release, err := sem.Acquire(ctx, fmt.Sprint(i), 1)
@@ -111,7 +111,7 @@ func TestSemaphore_LimitN(t *testing.T) {
 	var wg sync.WaitGroup
 
 	wg.Add(G)
-	for g := 0; g < G; g++ {
+	for range G {
 		go func() {
 			defer wg.Done()
 

--- a/shopfront/shopfront_test.go
+++ b/shopfront/shopfront_test.go
@@ -63,7 +63,7 @@ func TestShopFrontConcurrent(t *testing.T) {
 
 	N := 10000
 	wg := sync.WaitGroup{}
-	for i := 0; i < N; i++ {
+	for range N {
 		wg.Add(1)
 		go func() {
 			assert.NoError(t, c.RecordView(ctx, 1, 1))
@@ -91,13 +91,13 @@ func BenchmarkShopfront(b *testing.B) {
 	c := shopfront.New(rdb)
 
 	var ids []shopfront.ItemID
-	for i := 0; i < nItems; i++ {
+	for i := range nItems {
 		ids = append(ids, shopfront.ItemID(i))
 		require.NoError(b, c.RecordView(ctx, shopfront.ItemID(i), 42))
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	
+	for b.Loop() {
 		_, err := c.GetItems(ctx, ids, 42)
 		require.NoError(b, err)
 	}

--- a/structtags/structtags.go
+++ b/structtags/structtags.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 )
 
-func Unpack(req *http.Request, ptr interface{}) error {
+func Unpack(req *http.Request, ptr any) error {
 	if err := req.ParseForm(); err != nil {
 		return err
 	}
 
 	fields := make(map[string]reflect.Value)
 	v := reflect.ValueOf(ptr).Elem()
-	for i := 0; i < v.NumField(); i++ {
+	for i := range v.NumField() {
 		fieldInfo := v.Type().Field(i)
 		tag := fieldInfo.Tag
 		name := tag.Get("http")

--- a/structtags/structtags_test.go
+++ b/structtags/structtags_test.go
@@ -166,7 +166,7 @@ func BenchmarkUnpacker(b *testing.B) {
 	b.Run("user", func(b *testing.B) {
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			_ = Unpack(userRequest, user)
 		}
 	})
@@ -174,7 +174,7 @@ func BenchmarkUnpacker(b *testing.B) {
 	b.Run("good", func(b *testing.B) {
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			_ = Unpack(goodRequest, good)
 			_ = Unpack(orderRequest, order)
 		}
@@ -183,7 +183,7 @@ func BenchmarkUnpacker(b *testing.B) {
 	b.Run("order", func(b *testing.B) {
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			_ = Unpack(orderRequest, order)
 		}
 	})

--- a/testequal/assertions.go
+++ b/testequal/assertions.go
@@ -7,7 +7,7 @@ package testequal
 // Marks caller function as having failed but continues execution.
 //
 // Returns true iff arguments are equal.
-func AssertEqual(t T, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func AssertEqual(t T, expected, actual any, msgAndArgs ...any) bool {
 	panic("implement me")
 }
 
@@ -16,16 +16,16 @@ func AssertEqual(t T, expected, actual interface{}, msgAndArgs ...interface{}) b
 // Marks caller function as having failed but continues execution.
 //
 // Returns true iff arguments are not equal.
-func AssertNotEqual(t T, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func AssertNotEqual(t T, expected, actual any, msgAndArgs ...any) bool {
 	panic("implement me")
 }
 
 // RequireEqual does the same as AssertEqual but fails caller test immediately.
-func RequireEqual(t T, expected, actual interface{}, msgAndArgs ...interface{}) {
+func RequireEqual(t T, expected, actual any, msgAndArgs ...any) {
 	panic("implement me")
 }
 
 // RequireNotEqual does the same as AssertNotEqual but fails caller test immediately.
-func RequireNotEqual(t T, expected, actual interface{}, msgAndArgs ...interface{}) {
+func RequireNotEqual(t T, expected, actual any, msgAndArgs ...any) {
 	panic("implement me")
 }

--- a/testequal/assertions_test.go
+++ b/testequal/assertions_test.go
@@ -12,7 +12,7 @@ import (
 func TestEqual(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
-		expected, actual interface{}
+		expected, actual any
 	}{
 		{name: "int", expected: 1, actual: 1},
 		{name: "int8", expected: int8(1), actual: int8(1)},
@@ -41,7 +41,7 @@ func TestEqual(t *testing.T) {
 
 func TestNotEqual(t *testing.T) {
 	for _, tc := range []struct {
-		expected, actual interface{}
+		expected, actual any
 	}{
 		{expected: 1, actual: uint(1)},
 		{expected: uint(1), actual: int8(1)},
@@ -65,14 +65,14 @@ func TestNotEqual(t *testing.T) {
 		{expected: []int{1, 2, 3}, actual: []int{1, 3, 3}},
 		{expected: []int{1, 2, 3}, actual: []int{1, 2, 3, 4}},
 		{expected: []int{1, 2, 3, 4}, actual: []int{1, 2, 3}},
-		{expected: []int{}, actual: []interface{}{}},
+		{expected: []int{}, actual: []any{}},
 		{expected: []int{}, actual: []int(nil)},
 		{expected: []int{}, actual: map[int]int{}},
 		{expected: map[string]string{"a": "b"}, actual: map[string]string{}},
 		{expected: map[string]string{"a": "b"}, actual: map[string]string{"a": "d"}},
 		{expected: map[string]string{"a": "b"}, actual: map[string]string{"a": "b", "c": "b"}},
 		{expected: map[string]string{"a": "b", "c": "b"}, actual: map[string]string{"a": "b"}},
-		{expected: map[string]string{"a": "b"}, actual: map[string]interface{}{"a": "b"}},
+		{expected: map[string]string{"a": "b"}, actual: map[string]any{"a": "b"}},
 		{expected: map[string]string{}, actual: map[string]string(nil)},
 		{expected: map[int]int{}, actual: []int{}},
 		{expected: []byte{}, actual: []byte(nil)},
@@ -94,7 +94,7 @@ type mockT struct {
 	errMsg string
 }
 
-func (m *mockT) Errorf(format string, args ...interface{}) {
+func (m *mockT) Errorf(format string, args ...any) {
 	m.errMsg = fmt.Sprintf(format, args...)
 }
 
@@ -113,16 +113,16 @@ func TestErrorMessage(t *testing.T) {
 
 func BenchmarkRequireEqualInt64(b *testing.B) {
 	t := &mockT{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	
+	for b.Loop() {
 		RequireEqual(t, int64(1), int64(1))
 	}
 }
 
 func BenchmarkTestifyRequireEqualInt64(b *testing.B) {
 	t := &mockT{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	
+	for b.Loop() {
 		require.Equal(t, int64(1), int64(1))
 	}
 }
@@ -132,8 +132,8 @@ func BenchmarkRequireEqualString(b *testing.B) {
 	s2 := strings.Repeat("abacaba", 1024)
 
 	mockT := &mockT{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	
+	for b.Loop() {
 		RequireEqual(mockT, s1, s2)
 	}
 }
@@ -143,8 +143,8 @@ func BenchmarkTestifyRequireEqualString(b *testing.B) {
 	s2 := strings.Repeat("abacaba", 1024)
 
 	mockT := &mockT{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	
+	for b.Loop() {
 		require.Equal(mockT, s1, s2)
 	}
 }
@@ -154,8 +154,8 @@ func BenchmarkRequireEqualMap(b *testing.B) {
 	m2 := map[string]string{"a": "b", "c": "d", "e": "f"}
 
 	mockT := &mockT{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	
+	for b.Loop() {
 		RequireEqual(mockT, m1, m2)
 	}
 }
@@ -165,8 +165,8 @@ func BenchmarkTestifyRequireEqualMap(b *testing.B) {
 	m2 := map[string]string{"a": "b", "c": "d", "e": "f"}
 
 	mockT := &mockT{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	
+	for b.Loop() {
 		require.Equal(mockT, m1, m2)
 	}
 }

--- a/testequal/t.go
+++ b/testequal/t.go
@@ -5,7 +5,7 @@ package testequal
 // T is an interface wrapper for *testing.T
 // that contains only a small subset of methods.
 type T interface {
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	Helper()
 	FailNow()
 }

--- a/tools/testtool/busycheck.go
+++ b/tools/testtool/busycheck.go
@@ -13,7 +13,7 @@ import (
 func VerifyNoBusyGoroutines(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		time.Sleep(time.Millisecond)
 
 		var stacks []byte

--- a/tools/testtool/commands/list.go
+++ b/tools/testtool/commands/list.go
@@ -114,7 +114,7 @@ func listPrivateFiles(rootPackage string) []string {
 		log.Fatalf("failed: %v", err)
 	}
 
-	for _, line := range strings.Split(string(config), "\n") {
+	for line := range strings.SplitSeq(string(config), "\n") {
 		line = strings.Trim(line, " ")
 		if line != "" {
 			fname, _ := filepath.Abs(line)

--- a/tools/testtool/commands/report.go
+++ b/tools/testtool/commands/report.go
@@ -25,7 +25,7 @@ func reportTestResults(token string, task string, userID string, failed bool) er
 	var rsp *http.Response
 	var err error
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		rsp, err = http.PostForm(reportEndpoint, form)
 		if err != nil {
 			log.Printf("retrying report: %v", err)

--- a/tools/testtool/commands/test_submission_test.go
+++ b/tools/testtool/commands/test_submission_test.go
@@ -29,7 +29,7 @@ func listDirs(dir string) ([]string, error) {
 	return dirs, nil
 }
 
-func doTestSubmission(t *testing.T, studentRepo, privateRepo, problem string) error {
+func doTestSubmission(_ *testing.T, studentRepo, privateRepo, problem string) error {
 	// annotate := func(prefix string, f **os.File) func() {
 	// 	pr, pw, err := os.Pipe()
 	// 	require.NoError(t, err)

--- a/tools/testtool/freeport.go
+++ b/tools/testtool/freeport.go
@@ -26,7 +26,7 @@ func GetFreePort() (string, error) {
 }
 
 type logger interface {
-	Logf(format string, args ...interface{})
+	Logf(format string, args ...any)
 }
 
 // WaitForPort tries to connect to given local port with constant backoff.

--- a/tparallel/tparallel_test.go
+++ b/tparallel/tparallel_test.go
@@ -147,7 +147,7 @@ func TestParallelGroup(t *testing.T) {
 			t.Run(func(t *T) {
 				check.Sequential(2)
 
-				for i := 0; i < 10; i++ {
+				for i := range 10 {
 					t.Run(func(t *T) {
 						check.Sequential(3 + i)
 

--- a/urlfetch/main_test.go
+++ b/urlfetch/main_test.go
@@ -152,7 +152,7 @@ func TestURLFetch_order(t *testing.T) {
 	var callOrder []int
 
 	n := 1000
-	for i := 0; i < n; i++ {
+	for i := range n {
 		i := i
 		expectedCallOrder = append(expectedCallOrder, i)
 		s := strconv.Itoa(i)
@@ -168,7 +168,7 @@ func TestURLFetch_order(t *testing.T) {
 	defer s.Close()
 
 	urls := make([]string, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		urls[i] = s.URL + "/" + strconv.Itoa(i)
 	}
 

--- a/urlshortener/main_test.go
+++ b/urlshortener/main_test.go
@@ -69,7 +69,7 @@ func add(t *testing.T, c *resty.Client, shortenerURL, request string) string {
 	}
 
 	resp, err := c.R().
-		SetBody(map[string]interface{}{"url": request}).
+		SetBody(map[string]any{"url": request}).
 		SetResult(&Response{}).
 		Post(shortenerURL)
 
@@ -100,7 +100,7 @@ func TestURLShortener_redirect(t *testing.T) {
 	addURL := fmt.Sprintf("http://localhost:%s/shorten", port)
 
 	requests := make(map[string]struct{})
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		path := "/" + testtool.RandomName()
 		req := redirectTarget.URL + path
 		requests[path] = struct{}{}
@@ -169,7 +169,7 @@ func TestURLShortener_consistency(t *testing.T) {
 	}
 
 	var urls []string
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		urls = append(urls, testtool.RandomName())
 	}
 

--- a/utf8/reverse/reverse_test.go
+++ b/utf8/reverse/reverse_test.go
@@ -50,7 +50,7 @@ func BenchmarkReverse(b *testing.B) {
 
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = Reverse(input)
 	}
 }

--- a/utf8/spacecollapse/collapse_test.go
+++ b/utf8/spacecollapse/collapse_test.go
@@ -35,7 +35,7 @@ func BenchmarkCollapse(b *testing.B) {
 
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = CollapseSpaces(input)
 	}
 }

--- a/varfmt/fmt.go
+++ b/varfmt/fmt.go
@@ -2,6 +2,6 @@
 
 package varfmt
 
-func Sprintf(format string, args ...interface{}) string {
+func Sprintf(format string, args ...any) string {
 	return ""
 }

--- a/varfmt/fmt_test.go
+++ b/varfmt/fmt_test.go
@@ -9,49 +9,49 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	s := make([]interface{}, 1002)
+	s := make([]any, 1002)
 	s[10] = 1
 	s[100] = 2
 	s[1000] = 3
 
 	for _, tc := range []struct {
 		format string
-		args   []interface{}
+		args   []any
 		result string
 	}{
 		{
 			format: "{}",
-			args:   []interface{}{0},
+			args:   []any{0},
 			result: "0",
 		},
 		{
 			format: "{0} {0}",
-			args:   []interface{}{1},
+			args:   []any{1},
 			result: "1 1",
 		},
 		{
 			format: "{1} {5}",
-			args:   []interface{}{0, 1, 2, 3, 4, 5, 6},
+			args:   []any{0, 1, 2, 3, 4, 5, 6},
 			result: "1 5",
 		},
 		{
 			format: "{} {} {} {} {}",
-			args:   []interface{}{0, 1, 2, 3, 4},
+			args:   []any{0, 1, 2, 3, 4},
 			result: "0 1 2 3 4",
 		},
 		{
 			format: "{} {0} {0} {0} {}",
-			args:   []interface{}{0, 1, 2, 3, 4},
+			args:   []any{0, 1, 2, 3, 4},
 			result: "0 0 0 0 4",
 		},
 		{
 			format: "Hello, {2}",
-			args:   []interface{}{0, 1, "World"},
+			args:   []any{0, 1, "World"},
 			result: "Hello, World",
 		},
 		{
 			format: "He{2}o",
-			args:   []interface{}{0, 1, "ll"},
+			args:   []any{0, 1, "ll"},
 			result: "Hello",
 		},
 		{
@@ -80,27 +80,27 @@ func BenchmarkFormat(b *testing.B) {
 	for _, tc := range []struct {
 		name   string
 		format string
-		args   []interface{}
+		args   []any
 	}{
 		{
 			name:   "small int",
 			format: "{}",
-			args:   []interface{}{42},
+			args:   []any{42},
 		},
 		{
 			name:   "small string",
 			format: "{} {}",
-			args:   []interface{}{"Hello", "World"},
+			args:   []any{"Hello", "World"},
 		},
 		{
 			name:   "big",
 			format: strings.Repeat("{0}{1}", 1000),
-			args:   []interface{}{42, 43},
+			args:   []any{42, 43},
 		},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_ = Sprintf(tc.format, tc.args...)
 			}
 		})
@@ -111,27 +111,27 @@ func BenchmarkSprintf(b *testing.B) {
 	for _, tc := range []struct {
 		name   string
 		format string
-		args   []interface{}
+		args   []any
 	}{
 		{
 			name:   "small",
 			format: "%d",
-			args:   []interface{}{42},
+			args:   []any{42},
 		},
 		{
 			name:   "small string",
 			format: "%v %v",
-			args:   []interface{}{"Hello", "World"},
+			args:   []any{"Hello", "World"},
 		}, {
 			name:   "big",
 			format: strings.Repeat("%[0]v%[1]v", 1000),
-			args:   []interface{}{42, 43},
+			args:   []any{42, 43},
 		},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_ = fmt.Sprintf(tc.format, tc.args...)
 			}
 		})

--- a/waitgroup/waitgroup_test.go
+++ b/waitgroup/waitgroup_test.go
@@ -82,7 +82,7 @@ func TestWaitGroupAddMisuse(t *testing.T) {
 
 func TestWaitGroupRace(t *testing.T) {
 	// Run this test for about 1ms.
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		wg := New()
 		n := new(int32)
 		// spawn goroutine 1
@@ -110,7 +110,7 @@ func TestWaitGroupNoBusyWait(t *testing.T) {
 	wg.Add(1)
 	defer wg.Done()
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			wg.Wait()
 		}()

--- a/wordcount/main_test.go
+++ b/wordcount/main_test.go
@@ -133,7 +133,7 @@ b`,
 func parseStdout(data []byte) (map[string]int64, error) {
 	counts := make(map[string]int64)
 
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		if line == "" {
 			continue
 		}

--- a/wscat/main_test.go
+++ b/wscat/main_test.go
@@ -123,7 +123,7 @@ func TestWScat(t *testing.T) {
 	defer stop()
 
 	var in [][]byte
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		msg := []byte(testtool.RandomName())
 		in = append(in, msg)
 


### PR DESCRIPTION
Заметил, что встроенный в мой редактор lsp сервер предлагает изменения в файлы проекта (quickfix-ы). Не нашел нигде информации про то, как эти же изменения применить с помощью golangci-lint (понимаю только как найти какое-то подмножество изменений, отдельного линтера "делай как lsp" не нашел), поэтому написал [свой скриптец](https://github.com/ashurbekovz/gopls-apply-all-quickfixes) для этого и применил к проекту. Правда убрал изменения в директориях:

- `lectures/` - тут явно нужно смотреть аккуратнее
- `tools/testtool/testdata` - не хочется портить testdata
- `wasm/flappygopher/main.go` - тут убирался `select {}`, который явно нужен

В этом PR хотелось бы обсудить следующие моменты:
- Понять какое подмножество изменений действительно было бы неплохо применить, стоит ли его как-то расширить или ужать. Как по мне, текущие изменения из PR-а толковые и несколько освежают код.
- Обсудить необходимость циклов такого вида https://github.com/slon/shad-go/blob/main/waitgroup/waitgroup_test.go#L41 (то есть где условие выглядит как `!=`, а не `<`). Не смог понять причину использования `!=`. Почему мне это интересно - gopls такие циклы не предлагает сделать rangeint-овыми.
- Обсудить возможность автоматизации применения gopls на файлах проекта. На сколько такое вообще теоретически возможно и нужно? На примере уже отмененных файлов складывается впечатление, что наличие suggestion-ов от gopls не должно быть причиной для блока коммита. В то же время, неплохо бы проходиться профилактически gopls-ом по всему проекту хотя-бы в моменты обновлений версий go, но как такое автоматизировать? И на сколько вообще можно доверять lsp серверу? 
- Действительно ли нет утилиты, которая применяла бы gopls quickfix-ы на весь проект? Или это просто я не нашел?