### PR TITLE
add TestParallelInParallel in tparallel_test.go

### DIFF
--- a/tparallel/tparallel_test.go
+++ b/tparallel/tparallel_test.go
@@ -198,4 +198,21 @@ func TestTwoParallelSequences(t *testing.T) {
 			})
 		},
 	})
+}	
+
+func TestParallelInParallel(t *testing.T) {
+	check := &ConcurrencyChecker{t: t}
+	defer check.Finish(2)
+
+	Run([]func(*T){
+		func(t *T) {
+			check.Sequential(0)
+			t.Parallel()
+			
+			t.Run(func(t *T) {
+				t.Parallel()
+				check.Parallel(1, 1)
+			})
+		},
+	})
 }


### PR DESCRIPTION
Добавление теста для проверки того, что параллельные тесты дожидаются выполнения своих параллельных подтестов, а не просто завершаются при завершении тестовой функции.

Решил предложить добавить, потому что моё решение прошло имеющиеся тесты, но содержало ошибку, которая выявляется этим тестом.