### PR TITLE
Add test case for MapsEqual with different maps of the same length

### DIFF
--- a/genericsum/genericsum_test.go
+++ b/genericsum/genericsum_test.go
@@ -55,6 +55,7 @@ func TestMapsEqual(t *testing.T) {
 	var i int
 	assert.False(t, genericsum.MapsEqual(map[string]*int{"1": &i, "2": nil}, map[string]*int{"1": &i}))
 	assert.False(t, genericsum.MapsEqual(map[string]*int{"1": &i}, map[string]*int{"1": &i, "2": nil}))
+	assert.False(t, genericsum.MapsEqual(map[string]*int{"1": &i, "2": nil}, map[string]*int{"1": &i, "3": nil}))
 
 	assert.False(t, genericsum.MapsEqual(map[string]*int{"1": new(int)}, map[string]*int{"1": new(int)}),
 		"different pointers")


### PR DESCRIPTION
Сейчас тест пройдёт, если вместо честной проверки наличия ключа в map просто проверять, равны ли их размеры. Этот тесткейс отсекает как раз такое решение.