### PR TITLE
Additional reader test case: "\r\n" -> "\r"

### DIFF
--- a/externalsort/io_test.go
+++ b/externalsort/io_test.go
@@ -78,6 +78,11 @@ b
 			expected: []string{strings.Repeat("a", 65537)},
 		},
 		{
+			name:     "crlf-row",
+			in:       "a\r\nb",
+			expected: []string{"a\r", "b"},
+		},
+		{
 			name:     "half-reader",
 			in:       strings.Repeat("a", 1025),
 			wrappers: []Wrapper{iotest.HalfReader},


### PR DESCRIPTION
Add a separate test case for the Reader that checks it does not remove \r when handling \n.